### PR TITLE
Remove an unnecessary extern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate clap;
-
 fn main() {
   // Set up the command-line interface.
   clap::App::new("Paxos")


### PR DESCRIPTION
Remove an unnecessary extern. See https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html for details.

**Status:** Ready

**Fixes:** N/A
