### PR TITLE
Add tagref to the CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ rust:
 install:
   - rustup component add clippy
   - rustup component add rustfmt
+  - curl https://raw.githubusercontent.com/stepchowfun/tagref/master/install.sh -LSfs | sh
 script:
   - cargo clean
   - cargo fmt --all -- --check
   - cargo clippy -- --deny clippy::pedantic
   - cargo test
   - cargo run
+  - tagref


### PR DESCRIPTION
Add tagref to the CI checks. It was installed previously but was accidentally removed in https://github.com/stepchowfun/paxos/pull/6.

**Status:** Ready

**Fixes:** N/A
