### PR TITLE
Add a workaround for an issue with `cargo check`

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -114,6 +114,7 @@ tasks:
     command: |
       set -euo pipefail
       . $HOME/.cargo/env
+      find src -type f -name '*.rs' -exec touch {} +
       cargo check
 
   format:


### PR DESCRIPTION
Add a workaround for an issue with `cargo check`. The issue is that `cargo check` will ignore source files that it thinks haven't changed, even in some cases in which they have never been checked or built before. This is likely due to a combination of the behaviors of Cargo and Toast, as Toast intentionally does not preserve file timestamps.