### PR TITLE
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -43,7 +43,7 @@ pub struct ChooseResponse;
 pub fn prepare(request: &PrepareRequest, state: &mut State) -> PrepareResponse {
     info!(
         "Received prepare message:\n{}",
-        serde_yaml::to_string(request).unwrap(), // Serialization is safe. ,
+        serde_yaml::to_string(request).unwrap(), // Serialization is safe.
     );
 
     match &state.min_proposal_number {
@@ -65,7 +65,7 @@ pub fn prepare(request: &PrepareRequest, state: &mut State) -> PrepareResponse {
 pub fn accept(request: &AcceptRequest, state: &mut State) -> AcceptResponse {
     info!(
         "Received accept message:\n{}",
-        serde_yaml::to_string(request).unwrap(), // Serialization is safe. ,
+        serde_yaml::to_string(request).unwrap(), // Serialization is safe.
     );
     if state
         .min_proposal_number

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn settings() -> Settings {
                 .short("n")
                 .long(NODE_OPTION)
                 .help("Sets the index of the node corresponding to this instance")
-                .required(true), // [tag:node_required] ,
+                .required(true), // [tag:node_required]
         )
         .arg(
             Arg::with_name(PROPOSE_OPTION)
@@ -265,10 +265,10 @@ fn run(settings: Settings) -> impl Future<Item = (), Error = ()> {
                                             // panic already happened.
                                             let mut state_borrow = state.write().unwrap();
 
-                                            acceptor::$x(&payload, &mut state_borrow) // ,
+                                            acceptor::$x(&payload, &mut state_borrow)
                                         },
                                     ).map_err(|e|
-                                        Box::new(e) as Box<dyn Error + Send + Sync> // ,
+                                        Box::new(e) as Box<dyn Error + Send + Sync>
                                     ).and_then(move |response| {
                                         let state = state_for_write.clone();
                                         let settings = settings.clone();
@@ -280,7 +280,7 @@ fn run(settings: Settings) -> impl Future<Item = (), Error = ()> {
                                         state::write(&state_borrow, &settings.data_file_path)
                                             .map(|_| response)
                                             .map_err(|e|
-                                                Box::new(e) as Box<dyn Error + Send + Sync> // ,
+                                                Box::new(e) as Box<dyn Error + Send + Sync>
                                             )
                                     }).map(|response|
                                         Response::new(Body::from(

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,7 +82,7 @@ pub fn broadcast<
                                 // The `unwrap` is safe because serialization should never fail.
                                 bincode::serialize(&payload).unwrap(),
                             ))
-                            .unwrap(), // Safe since we constructed a well-formed request ,
+                            .unwrap(), // Safe since we constructed a well-formed request
                     )
                     .and_then(|response| {
                         response.into_body().concat2().map(|body| {


### PR DESCRIPTION
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check.

**Status:** Ready

**Fixes:** N/A
