### PR TITLE
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: stepchowfun/toast/.github/actions/toast@main
       with:
         tasks: build test lint release run
-        repo: stephanmisc/toast
+        docker_repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}
     - run: |
         # Make Bash not silently ignore errors.


### PR DESCRIPTION
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow.

**Status:** Ready

**Fixes:** N/A