### PR TITLE
Update the way lints are configured to use Rust's new `manifest-lint` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://github.com/stepchowfun/paxos"
 repository = "https://github.com/stepchowfun/paxos"
 readme = "README.md"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]
 bincode = "1"
 env_logger = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod acceptor;
 mod config;
 mod proposer;


### PR DESCRIPTION
Update the way lints are configured to use Rust's new `manifest-lint` feature

**Status:** Ready

**Fixes:** N/A