### PR TITLE
Bring back the CI badge with the new URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Paxos
 
+[![Build status](https://github.com/stepchowfun/paxos/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stepchowfun/paxos/actions?query=branch%3Amain)
+
 This is a reference implementation of single-decree Paxos.
 
 ## Configuration


### PR DESCRIPTION
Bring back the CI badge with the new URL scheme.

**Status:** Ready

**Fixes:** N/A