### PR TITLE
Migrate to yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,9 +670,9 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serde_yaml",
  "textwrap",
  "tokio",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -863,19 +869,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1078,12 +1071,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1294,6 +1281,19 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ log = "0.4"
 rand = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+yaml_serde = "0.10"
 textwrap = { version = "0.16", features = ["hyphenation", "smawk", "terminal_size", "unicode-linebreak", "unicode-width"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -45,7 +45,7 @@ fn prepare(
 ) -> PrepareResponse {
     debug!(
         "Received prepare request:\n{}",
-        serde_yaml::to_string(request).unwrap(), // Serialization is safe.
+        yaml_serde::to_string(request).unwrap(), // Serialization is safe.
     );
 
     if let Some(requested_proposal_number) = request.proposal_number {
@@ -87,7 +87,7 @@ fn accept(
 ) -> AcceptResponse {
     debug!(
         "Received accept request:\n{}",
-        serde_yaml::to_string(request).unwrap(), // Serialization is safe.
+        yaml_serde::to_string(request).unwrap(), // Serialization is safe.
     );
 
     if state
@@ -191,8 +191,8 @@ async fn handle_request(
             // Respond with a representation of the program state. The `unwrap`s
             // are safe because serialization should never fail.
             let state = context.state.read().await;
-            let durable_state_repr = serde_yaml::to_string(&state.0).unwrap();
-            let volatile_state_repr = serde_yaml::to_string(&state.1).unwrap();
+            let durable_state_repr = yaml_serde::to_string(&state.0).unwrap();
+            let volatile_state_repr = yaml_serde::to_string(&state.1).unwrap();
             Ok(Response::new(Full::new(Bytes::from(format!(
                 "System operational.\n\n\
                 Durable state:\n\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub async fn read(path: &Path) -> io::Result<Config> {
     file.read_to_end(&mut contents).await?;
 
     // Deserialize the data.
-    serde_yaml::from_slice(&contents).map_err(|error| {
+    yaml_serde::from_slice(&contents).map_err(|error| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
@@ -43,7 +43,7 @@ nodes: []
 
         let result = Config { nodes: vec![] };
 
-        assert_eq!(serde_yaml::from_str::<Config>(config).unwrap(), result);
+        assert_eq!(yaml_serde::from_str::<Config>(config).unwrap(), result);
     }
 
     #[test]
@@ -58,7 +58,7 @@ nodes:
             nodes: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000)],
         };
 
-        assert_eq!(serde_yaml::from_str::<Config>(config).unwrap(), result);
+        assert_eq!(yaml_serde::from_str::<Config>(config).unwrap(), result);
     }
 
     #[test]
@@ -79,6 +79,6 @@ nodes:
             ],
         };
 
-        assert_eq!(serde_yaml::from_str::<Config>(config).unwrap(), result);
+        assert_eq!(yaml_serde::from_str::<Config>(config).unwrap(), result);
     }
 }

--- a/src/proposer.rs
+++ b/src/proposer.rs
@@ -53,7 +53,7 @@ pub async fn propose(
         debug!(
             "Preparing proposal number:\n{}",
             // Serialization is safe.
-            serde_yaml::to_string(&proposal_number).unwrap(),
+            yaml_serde::to_string(&proposal_number).unwrap(),
         );
         let prepare_responses = broadcast_quorum::<PrepareResponse>(
             &client,
@@ -91,7 +91,7 @@ pub async fn propose(
         debug!(
             "Requesting acceptance of value `{}`.",
             // The `unwrap` is safe because serialization should never fail.
-            serde_yaml::to_string(&proposal_number).unwrap(),
+            yaml_serde::to_string(&proposal_number).unwrap(),
         );
         let accept_responses = broadcast_quorum::<AcceptResponse>(
             &client,


### PR DESCRIPTION
Migrate from the deprecated, unmaintained `serde_yaml` crate to the maintained `yaml_serde` fork. Update the YAML call sites and lockfile accordingly.

**Status:** Ready

**Fixes:** N/A