### PR TITLE
Add a tagref file reference for the example configuration in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is a reference implementation of single-decree Paxos.
 
 By default, the program looks for a configuration file named `config.yml` in the working directory. This file describes the cluster membership. An [example configuration](https://github.com/stepchowfun/paxos/blob/main/config.yml) is provided in this repository.
 
+<!-- [file:config.yml] -->
+
 ## Usage
 
 For a simple demonstration, run the following commands from separate terminals in the repository root:


### PR DESCRIPTION
The README's Configuration section links to the example `config.yml`. This adds a hidden `[file:config.yml]` tagref reference in an HTML comment under that paragraph, so `tagref check` (run by `toast lint`) will fail if the file is ever moved or deleted without updating the README.

**Status:** Ready

**Fixes:** N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)