### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-bytes = "1.12.0"
+bytes = "1.12.1"
 clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
 env_logger = "0.11.11"
 futures = "0.3.32"


### PR DESCRIPTION
Update `bytes` from `1.12.0` to `1.12.1`. The upstream release fixes panic handling when `Box::new` panics (tokio-rs/bytes#837). No code changes were required.

**Status:** Ready

**Fixes:** N/A