### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"


### PR DESCRIPTION
Updates transitive Cargo dependencies after confirming direct manifest dependencies, Rust/toolchain pins, GitHub Actions pins, and copyright years are already current.

- Updates `zmij` from 1.0.21 to 1.0.22; upstream release is a large internal sync for the float formatter crate, with no direct API usage in this repo.

**Status:** Ready

**Fixes:** N/A