### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.12.1"
 clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
 env_logger = "0.11.11"
 futures = "0.3.32"
-http-body-util = "0.1.3"
+http-body-util = "0.1.4"
 hyper = { version = "1.10.1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 log = "0.4.33"


### PR DESCRIPTION
Update `http-body-util` from 0.1.3 to 0.1.4. The upstream release adds helper APIs (`Fused`, `BodyExt::into_stream`, `Full::into_inner`, and inspect combinators); this repo does not need source changes. Rust, GitHub Actions, submodules, and copyright year were already current.

**Status:** Ready

**Fixes:** N/A