### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.4.0
+      uses: docker/login-action@v4.5.1
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update `docker/login-action` from 4.4.0 to 4.5.1. The 4.5.x releases add Docker Hub OIDC support, update internal dependencies, and retain the existing username/password inputs used by this workflow.

**Status:** Ready

**Fixes:** N/A